### PR TITLE
Updated Mischief Links and Icons

### DIFF
--- a/src/assets/items/events/days-of-mischief.jsonc
+++ b/src/assets/items/events/days-of-mischief.jsonc
@@ -11,7 +11,7 @@
       "primary": {}
     },
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Spooky_Bat_Cape"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2020#Spooky_Bat_Cape"
     },
     "order": 965
   },
@@ -23,7 +23,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2b/Icon_hair_mischief_pumpkin.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d5/Hair_halloween_pumpkin.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Hungry_Pumpkin_Hat"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2020#Hungry_Pumpkin_Hat"
     },
     "order": 299
   },
@@ -35,7 +35,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/95/Icon_hair_mischief_witch_hat.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/25/Crooked_witch_hat_hair_v2.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Hat"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2020#Mischief_Witch_Hat"
     },
     "order": 300
   },
@@ -51,7 +51,7 @@
       "primary": {}
     },
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Web_Cape"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2020#Mischief_Web_Cape"
     },
     "order": 966
   },
@@ -84,7 +84,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e8/Icon_2021_mischief_table.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Prop_2021_mischief_table_open.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Spooky_Dining_Set"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Spooky_Dining_Set"
     },
     "order": 703
   },
@@ -96,7 +96,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Icon_2021_mischief_leaf_cape-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Cape_2021_mischief_leaf_cape.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Withered_Cape"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Withered_Cape"
     },
     "order": 967
   },
@@ -108,7 +108,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Icon_2021_mischief_long_hair.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/12/Hair_2021_mischief_long_hair.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Hair"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Witch_Hair"
     },
     "order": 302
   },
@@ -120,7 +120,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/Icon_2021_mischief_pumpkin_prop.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/45/Days-of-mischief-2021-pumpkin-prop-closeup.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Pumpkin_Prop"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Pumpkin_Prop"
     },
     "order": 704
   },
@@ -132,7 +132,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cc/Icon_2021_mischief_iap_hair.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7b/Hair_2021_mischief_web_hair_iap.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Spider_Quiff"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Spider_Quiff"
     },
     "order": 303
   },
@@ -148,7 +148,7 @@
       "primary": {}
     },
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Jumper"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Witch_Jumper"
     },
     "order": 89
   },
@@ -160,7 +160,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Mischief-Witch-Jumper-Shoes-icon-Credit-Morybel.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f6/Mischief-Witch-Jumper-Shoes.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Witch_Jumper"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Witch_Jumper"
     },
     "order": 139
   },
@@ -172,7 +172,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a8/Icon_2021_mischief_headpiece.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Hair_2021_mischief_headpiece_iap.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Withered_Antlers"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2021#Mischief_Withered_Antlers"
     },
     "order": 402
   },
@@ -184,7 +184,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6a/Days-of-Mischief-Cat-Hair-Icon-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/Days-of-Mischief-2022-Cat-hairstyle.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Tufted_Hair"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2022#Mischief_Tufted_Hair"
     },
     "order": 301
   },
@@ -202,7 +202,7 @@
       "secondary": {}
     },
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Cat_Mask"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2022#Cat_Mask"
     },
     "order": 499
   },
@@ -218,7 +218,7 @@
       "primary": {}
     },
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Cat_Cape"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2022#Cat_Cape"
     },
     "order": 968
   },
@@ -230,7 +230,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/69/Days-of-Mischief-Cat-Prop-Icon-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b8/Days-of-Mischief-Backpack-Cat-Prop.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Feline_Familiar_Prop"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2022#Feline_Familiar_Prop"
     },
     "order": 705
   },
@@ -243,7 +243,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Mischief-Gossamer-Cape-back.png",
     "order": 970,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Gossamer_Cape"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2023#Mischief_Gossamer_Cape"
     }
   },
   {
@@ -259,7 +259,7 @@
       "previewUrl": "https://sky-planner.com/assets/game/dyes/cape/Mischef_crabulacape.webp"
     },
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Crabula_Cloak"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2023#Mischief_Crabula_Cloak"
     }
   },
   {
@@ -271,7 +271,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/Mischief-Crabula-Mask.png",
     "order": 500,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Crabula_Mask"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2023#Mischief_Crabula_Mask"
     }
   },
   {
@@ -287,7 +287,7 @@
     },
     "order": 90,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Goth_Garment"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2023#Mischief_Goth_Garment"
     }
   },
   {
@@ -299,7 +299,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6b/Mischief-Goth-Boots.png",
     "order": 140,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Goth_Boots"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2023#Mischief_Goth_Boots"
     }
   },
   {
@@ -311,7 +311,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Mischief-Crabkin-Accessory.png",
     "order": 366,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Crabkin_Accessory"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2023#Mischief_Crabkin_Accessory"
     }
   },
   {
@@ -330,7 +330,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ed/Mischief-Raven-Feathered-Cloak-back.png",
     "order": 972,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Raven-Feathered_Cloak"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2024#Mischief_Raven-Feathered_Cloak"
     }
   },
   {
@@ -342,7 +342,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Mischief-Withered-Broom.png",
     "order": 615,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Withered_Broom"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2024#Mischief_Withered_Broom"
     }
   },
   {
@@ -354,7 +354,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fd/Mischief-Spider-Bun-front.png",
     "order": 304,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Spider_Bun"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2024#Mischief_Spider_Bun"
     }
   },
   {
@@ -366,7 +366,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/Mischief-Cauldron.png",
     "order": 819,
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Cauldron"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2024#Mischief_Cauldron"
     }
   },
   {
@@ -382,7 +382,7 @@
       "previewUrl": "https://sky-planner.com/assets/game/dyes/Mischief_sticker.jpg"
     },
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief#Mischief_Star_Sticker"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2024#Mischief_Star_Sticker"
     }
   },
   {
@@ -403,6 +403,9 @@
       "primary": {},
       "previewUrl": "https://sky-planner.com/assets/game/dyes/hair/Mischief_crowhat.jpg"
     },
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Puzzlewright's_Brimmed_Hat"
+    },
     "order": 305
   },
   {
@@ -416,6 +419,9 @@
       "primary": {},
       "previewUrl": "https://sky-planner.com/assets/game/dyes/Mischief_cattail.jpg"
     },
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Feline_Accessory_Duo"
+    },
     "order": 559
   },
   {
@@ -428,6 +434,9 @@
     "dye": {
       "primary": {},
       "previewUrl": "https://sky-planner.com/assets/game/dyes/hair-accessory/Mischief_catears.jpg"
+    },
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Feline_Accessory_Duo"
     },
     "order": 367
   },
@@ -444,6 +453,9 @@
       "previewUrl": "https://sky-planner.com/assets/game/dyes/mask/Mischief_crowmask.jpg",
       "infoUrl": "https://sky-planner.com/assets/game/dyes/mask/2slots_Mischief_crowmask.jpg"
     },
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Beak_Mask"
+    },
     "order": 501
   },
   {
@@ -457,6 +469,9 @@
       "primary": {},
       "previewUrl": "https://sky-planner.com/assets/game/dyes/cape/Mischief_curtaincape.jpg"
     },
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Goth_Cape"
+    },
     "order": 969
   },
   {
@@ -466,6 +481,9 @@
     "name": "Mischief Leaf Hat",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0f/Days-of-Mischief-Leaf-Hat-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c4/Days-of-Mischief-Leaf-Hat-front.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Leaf_Hat"
+    },
     "order": 368
   },
   {
@@ -475,6 +493,9 @@
     "name": "Mischief Crabkin Lamp",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7a/Days-of-Mischief-Crabkin-Lamp-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Days-of-Mischief-Crabkin-Lamp.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Crabkin_Lamp"
+    },
     "order": 681
   },
   {
@@ -484,6 +505,9 @@
     "name": "Mischief Cobweb Decor",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bd/Days-of-Mischief-Cobweb-Decor-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/52/Days-of-Mischief-Cobweb-Decor.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Cobweb_Decor"
+    },
     "order": 682
   },
   {
@@ -493,6 +517,9 @@
     "name": "Mischief Dark Dragon Rug",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d0/Days-of-Mischief-Dark-Dragon-Rug-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a4/Days-of-Mischief-Dark-Dragon-Rug.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Dark_Dragon_Rug"
+    },
     "order": 680
   },
   {
@@ -502,6 +529,9 @@
     "name": "Mischief Withered Sapling",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/55/Days-of-Mischief-Withered-Sapling-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c9/Days-of-Mischief-Withered-Sapling.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Mischief_Withered_Sapling"
+    },
     "order": 683
   },
   {
@@ -511,6 +541,9 @@
     "name": "Puzzle Box",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f5/Days-of-Mischief-Puzzle-Box-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/93/Days-of-Mischief-Puzzle-Box.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Puzzle_Box"
+    },
     "order": 725
   },
   {
@@ -520,6 +553,9 @@
     "name": "Puzzle Chest",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d7/Days-of-Mischief-Puzzle-Chest-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/04/Days-of-Mischief-Puzzle-Chest.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Puzzle_Chest"
+    },
     "order": 724
   },
   {
@@ -529,6 +565,9 @@
     "name": "Puzzle Cage",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Days-of-Mischief-Puzzle-Cage-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f9/Days-of-Mischief-Puzzle-Cage.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Puzzle_Cage"
+    },
     "order": 726
   },
   {
@@ -536,7 +575,11 @@
     "guid": "4wA4nwGZUM",
     "type": "Prop",
     "name": "Red Dye Sticker",
-    "icon": "https://sky-planner.com/assets/game/items/2845.png",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Mind-Sticker-icon.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Mind-Sticker.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Wall_Painting_Props"
+    },
     "order": 625
   },
   {
@@ -544,7 +587,11 @@
     "guid": "HUjA3utlNd",
     "type": "Prop",
     "name": "Purple Dye Sticker",
-    "icon": "https://sky-planner.com/assets/game/items/2846.png",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Void-Sticker-icon.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/80/Void-Sticker.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Wall_Painting_Props"
+    },
     "order": 626
   },
   {
@@ -552,7 +599,11 @@
     "guid": "G9RHsCv5AB",
     "type": "Prop",
     "name": "Black Dye Sticker",
-    "icon": "https://sky-planner.com/assets/game/items/2847.png",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d2/Darkness-Sticker-icon.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Darkness-Sticker.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Wall_Painting_Props"
+    },
     "order": 627
   },
   {
@@ -560,7 +611,11 @@
     "guid": "hrH037AVN5",
     "type": "Prop",
     "name": "White Dye Sticker",
-    "icon": "https://sky-planner.com/assets/game/items/2848.png",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Light-Sticker-icon.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cf/Light-Sticker.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Mischief/2025#Wall_Painting_Props"
+    },
     "order": 628
   },
   {


### PR DESCRIPTION
Updated all the links and added links to the 2025 items and updated the icon images for the stickers and added the preview images for them.

This should all hopefully be correct, I wasn't to check since this we don't have the `npm run start` script like the Planner repo did.