### PR TITLE
Lazy Days Changed Bunny Accessory IAP to Returning

### DIFF
--- a/src/assets/iaps/events/lazy-days.jsonc
+++ b/src/assets/iaps/events/lazy-days.jsonc
@@ -26,6 +26,7 @@
     "guid": "mIrP9HEc7D",
     "name": "Bunny Accessory",
     "price": 2.99,
+    "returning": true,
     "items": ["EEFIpR6x7Q"]
   }
   // #endregion


### PR DESCRIPTION
Changed Bunny Accessory to "Returning IAP" instead of "New IAP" for Lazy Days since it was introduced in Days of Summer Lights (2021)

[Wiki Link](https://sky-children-of-the-light.fandom.com/wiki/Lazy_Days#Bunny_Accessory)
<img width="1085" height="497" alt="image" src="https://github.com/user-attachments/assets/f5e62f90-4b4a-4279-a0a0-78d12d4938cf" />
