### PR TITLE
Renamed Areas (0.32.0)

### DIFF
--- a/src/assets/areas/aviary-village.jsonc
+++ b/src/assets/areas/aviary-village.jsonc
@@ -1,7 +1,7 @@
 [
   {
     "guid": "zewkN917oz",
-    "name": "Home Space",
+    "name": "Home",
     "imageUrl": "https://sky-planner.com/assets/game/areas/aviary/home-720.webp",
     "mapData": { "position": [-478, 415.75] },
     "mapShrines": ["NKLJ5lCZiL"],

--- a/src/assets/areas/daylight-prairie.jsonc
+++ b/src/assets/areas/daylight-prairie.jsonc
@@ -1,7 +1,7 @@
 [
   {
     "guid": "Cmo9TPPpyH",
-    "name": "Prairie Social Space",
+    "name": "Prairie Gateway",
     "imageUrl": "https://sky-planner.com/assets/game/areas/prairie/social-720.webp",
     "wingedLights": ["fl1Z3bEx81"],
     "mapShrines": ["UZU8IWRFTQ"],
@@ -25,7 +25,7 @@
   },
   {
     "guid": "V17jvM6lWL",
-    "name": "Village Islands",
+    "name": "Prairie Village",
     "imageUrl": "https://sky-planner.com/assets/game/areas/prairie/islands-720.webp",
     "spirits": ["48jm5EQzfU", "K3CIxcDSjq", "WFjSczlPTV", "R4ILdPamhd"],
     "wingedLights": ["_SJva8zUYc", "D22kvZx25W", "4lNlq0Raah"],
@@ -41,7 +41,7 @@
   },
   {
     "guid": "bq6AFJ7avU",
-    "name": "8-Player Puzzle Area",
+    "name": "Prairie Heights",
     "imageUrl": "https://sky-planner.com/assets/game/areas/prairie/8p-720.webp",
     "spirits": ["gtbbZnpLbt"],
     "wingedLights": ["Sc2aim9ro1"],
@@ -67,7 +67,7 @@
   },
   {
     "guid": "BwpwRMfq1X",
-    "name": "Prairie Caves",
+    "name": "Prairie Cave",
     "imageUrl": "https://sky-planner.com/assets/game/areas/prairie/cave-720.webp",
     "spirits": ["MyLI80npmW", "Q-N8n-0b8O"],
     "wingedLights": ["tGV1WQd1yk", "K-eoMvklId"],
@@ -81,7 +81,7 @@
   },
   {
     "guid": "HHem4xrBb6",
-    "name": "Bird's Nest",
+    "name": "Bird Nest",
     "imageUrl": "https://sky-planner.com/assets/game/areas/prairie/nest-720.webp",
     "spirits": ["KM1xzU9v5P", "jncJKA4IaM", "PYsLThJYPx"],
     "wingedLights": ["GNDWMxbvTD", "PBt-1vrXFA"],
@@ -95,7 +95,7 @@
   },
   {
     "guid": "W4xXNx8SSq",
-    "name": "Sanctuary Island",
+    "name": "Sanctuary Islands",
     "imageUrl": "https://sky-planner.com/assets/game/areas/prairie/sanctuary-720.webp",
     "spirits": [
       "0IoADuWn1P",

--- a/src/assets/areas/eye-of-eden.jsonc
+++ b/src/assets/areas/eye-of-eden.jsonc
@@ -1,7 +1,7 @@
 [
   {
     "guid": "vWlW190-P1",
-    "name": "Eden Entrance",
+    "name": "Gate of Eden",
     "imageUrl": "https://sky-planner.com/assets/game/areas/eden/entrance-720.webp",
     "mapShrines": ["QBGEZURf1h"],
     "mapData": { "position": [-193.25, 275.75] },
@@ -65,7 +65,7 @@
   },
   {
     "guid": "Ub5s1RiDA1",
-    "name": "Orbit",
+    "name": "The Passage",
     "imageUrl": "https://sky-planner.com/assets/game/areas/eden/orbit-720.webp",
     "spirits": [
       "l8tl0mHCWH",

--- a/src/assets/areas/golden-wasteland.jsonc
+++ b/src/assets/areas/golden-wasteland.jsonc
@@ -1,7 +1,7 @@
 [
   {
     "guid": "R4I-lYbUUO",
-    "name": "Wasteland Social Space",
+    "name": "Wasteland Gateway",
     "imageUrl": "https://sky-planner.com/assets/game/areas/wasteland/social-720.webp",
     "mapShrines": ["EaNImb7KpI"],
     "mapData": { "position": [-283, 339.25] },
@@ -76,7 +76,7 @@
   },
   {
     "guid": "jP2N7n1mcw",
-    "name": "Battlefield",
+    "name": "Wasteland Battlefield",
     "imageUrl": "https://sky-planner.com/assets/game/areas/wasteland/battlefield-720.webp",
     "spirits": ["nwpDbbbWcw"],
     "wingedLights": ["3rn0JHgV53", "MVmgO5kOUE"],
@@ -140,7 +140,7 @@
   },
   {
     "guid": "pZbxK8tM_J",
-    "name": "The Land in the Distant Past",
+    "name": "The Last City",
     "spirits": ["aO0n7dAWvc", "Jq1bIftHV5", "zdstJkDMg5", "2FQrdh4aCQ"],
     "connections": [{ "area": "mT6bVNovBW" }]
   }

--- a/src/assets/areas/hidden-forest.jsonc
+++ b/src/assets/areas/hidden-forest.jsonc
@@ -1,7 +1,7 @@
 [
   {
     "guid": "A2--yR5CJk",
-    "name": "Forest Social Space",
+    "name": "Forest Gateway",
     "imageUrl": "https://sky-planner.com/assets/game/areas/forest/social-720.webp",
     "mapShrines": ["AKRMG2oyjD"],
     "mapData": { "position": [-373.5, 120.5] },
@@ -26,7 +26,7 @@
   },
   {
     "guid": "ZlV4HpsDGF",
-    "name": "Rainy Forest",
+    "name": "Forest Courtyard",
     "imageUrl": "https://sky-planner.com/assets/game/areas/forest/rainy-720.webp",
     "spirits": ["LwcCtbnGuF", "94UEgV7ic1", "RG-Z1xwway"],
     "wingedLights": ["zJCYOFxRNR"],
@@ -76,7 +76,7 @@
   },
   {
     "guid": "FlcxMwdsU7",
-    "name": "Underground Cavern",
+    "name": "Forest Cavern",
     "imageUrl": "https://sky-planner.com/assets/game/areas/forest/cavern-720.webp",
     "spirits": ["gcEV41jg3U"],
     "wingedLights": ["iaLuQ06e4T", "pBAU_FHObL", "3NFT1aCRpY", "xF6rfLZpef"],
@@ -103,7 +103,7 @@
   },
   {
     "guid": "iYC53UMrvL",
-    "name": "Broken Bridge",
+    "name": "Boneyard",
     "imageUrl": "https://sky-planner.com/assets/game/areas/forest/bridge-720.webp",
     "spirits": [
       "L_0YoE4O8Z",
@@ -134,7 +134,7 @@
   },
   {
     "guid": "jY6mM3Io4T",
-    "name": "Forest End",
+    "name": "Sacred Pond",
     "imageUrl": "https://sky-planner.com/assets/game/areas/forest/end-720.webp",
     "wingedLights": ["s_UlGNscIQ"],
     "mapShrines": ["nlqV1yGTCM"],
@@ -143,7 +143,7 @@
   },
   {
     "guid": "Ay0oFK8FSv",
-    "name": "Assembly Treehouse",
+    "name": "The Treehouse",
     "imageUrl": "https://sky-planner.com/assets/game/areas/forest/treehouse-720.webp",
     "spirits": ["cpwvdVEzKN"],
     "wingedLights": ["H7uvC7nb8U", "7_WXb7Uu8Z"],
@@ -158,7 +158,7 @@
   },
   {
     "guid": "_dSyX-Uwrh",
-    "name": "Wind Paths",
+    "name": "The Wind Paths",
     "imageUrl": "https://sky-planner.com/assets/game/areas/forest/wind-720.webp",
     "spirits": [
       "FF8u1g9XI_",

--- a/src/assets/areas/isle-of-dawn.jsonc
+++ b/src/assets/areas/isle-of-dawn.jsonc
@@ -39,7 +39,7 @@
   },
   {
     "guid": "6MuptjUV8B",
-    "name": "Isle Temple",
+    "name": "Dawn Temple",
     "imageUrl": "https://sky-planner.com/assets/game/areas/isle/temple-720.webp",
     "mapShrines": ["gZHTmFJ0_S"],
     "mapData": { "position": [-398.13, 305.5] },
@@ -60,7 +60,7 @@
   },
   {
     "guid": "ht8PxRB-MY",
-    "name": "Butterfly Cave",
+    "name": "Dawn Overlook",
     "imageUrl": "https://sky-planner.com/assets/game/areas/isle/butterfly-720.webp",
     "wingedLights": ["vGCXUjMLfB"],
     "mapData": { "position": [-405.13, 321.5] },

--- a/src/assets/areas/valley-of-triumph.jsonc
+++ b/src/assets/areas/valley-of-triumph.jsonc
@@ -1,7 +1,7 @@
 [
   {
     "guid": "LUkrOYNjEy",
-    "name": "Valley Social Space",
+    "name": "Valley Gateway",
     "imageUrl": "https://sky-planner.com/assets/game/areas/valley/social-720.webp",
     "mapShrines": ["-R9H4i_Jz3"],
     "mapData": { "position": [-257.13, 189.63] },
@@ -9,7 +9,7 @@
   },
   {
     "guid": "u3rc8C3sMb",
-    "name": "Ice Rink",
+    "name": "Frozen Lake",
     "imageUrl": "https://sky-planner.com/assets/game/areas/valley/rink-720.webp",
     "spirits": ["4KCKJxR56G", "JROKFatVLC", "bHCSyFQ4u-", "9y_5scrYa9"],
     "wingedLights": ["5BM1uqQvM4", "vKEMuduC0F", "_rmaySa6NL"],
@@ -23,7 +23,7 @@
   },
   {
     "guid": "iRWfJCMxFB",
-    "name": "Citadel",
+    "name": "The Citadel",
     "imageUrl": "https://sky-planner.com/assets/game/areas/valley/citadel-720.webp",
     "spirits": ["yUp189PWVS", "CfXORyMFx4", "H5iKZChQIK"],
     "wingedLights": ["DjuNbgmKq5", "D9Z9c3mRDf"],
@@ -33,7 +33,7 @@
   },
   {
     "guid": "8Zn5GPbx1U",
-    "name": "Sliding Race",
+    "name": "Lower Valley Track",
     "imageUrl": "https://sky-planner.com/assets/game/areas/valley/slide-720.webp",
     "wingedLights": ["Tmg19lVERk"],
     "mapShrines": ["r2NNvf4jdl"],
@@ -42,7 +42,7 @@
   },
   {
     "guid": "uMoS_cHn0R",
-    "name": "Flying Race",
+    "name": "Upper Valley Track",
     "imageUrl": "https://sky-planner.com/assets/game/areas/valley/fly-720.webp",
     "wingedLights": ["sfDl46vj4O", "N6KMjaxez6"],
     "mapShrines": ["Aq4k2P-fVB"],
@@ -59,7 +59,7 @@
   },
   {
     "guid": "GC4SmA2CUz",
-    "name": "Coliseum",
+    "name": "The Coliseum",
     "imageUrl": "https://sky-planner.com/assets/game/areas/valley/coliseum-720.webp",
     "spirits": [
       "OaAUJHNIjE",

--- a/src/assets/areas/vault-of-knowledge.jsonc
+++ b/src/assets/areas/vault-of-knowledge.jsonc
@@ -15,7 +15,7 @@
   },
   {
     "guid": "wKZdWMMIWa",
-    "name": "Vault Elevator",
+    "name": "Lower Vault",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/elevator-720.webp",
     "spirits": ["_8CvQjUnQg", "CH6e-TQz6n"],
     "mapShrines": ["Mt6uDBigUP"],
@@ -32,7 +32,7 @@
   },
   {
     "guid": "-xkmkbpRyN",
-    "name": "Vault Third Floor",
+    "name": "Middle Vault",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/third-720.webp",
     "spirits": ["1OGD_H3a7X"],
     "wingedLights": ["Hn7mU7ktxt"],
@@ -42,7 +42,7 @@
   },
   {
     "guid": "BxTngnB1PV",
-    "name": "Vault Fourth Floor",
+    "name": "Upper Vault",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/fourth-720.webp",
     "spirits": ["HeJISF946a", "Gi75RcvXd0", "KZaVtTUdlR", "mZZ-MkZJ1x"],
     "wingedLights": ["Zzvpdwh0wl", "I-vGwH81iB"],
@@ -60,7 +60,7 @@
   },
   {
     "guid": "ZiqYHd176H",
-    "name": "Vault Summit",
+    "name": "Vault Temple",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/summit-720.webp",
     "wingedLights": ["uiNKKn25L-"],
     "mapShrines": ["4jtpTFZ39o"],
@@ -69,7 +69,7 @@
   },
   {
     "guid": "HbKvg_BOyc",
-    "name": "Vault Archives",
+    "name": "The Archive",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/archive-720.webp",
     "spirits": ["7EzWoLR1w4"],
     "wingedLights": ["W9fiK8mWQK", "4uUGCJEgq3"],
@@ -79,7 +79,7 @@
   },
   {
     "guid": "wrHKGEg2Kc",
-    "name": "Vault Collab Room",
+    "name": "Hall of Stories",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/new-collab-temp.webp",
     "mapShrines": ["eroCc1CGcC"],
     "mapData": { "position": [-214, 395.5] },
@@ -144,7 +144,7 @@
   },
   {
     "guid": "schNrmq0ID",
-    "name": "Office",
+    "name": "Secret Area",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/secret-720.webp",
     "spirits": [
       "ExkE9a7QJ0",
@@ -207,7 +207,7 @@
   },
   {
     "guid": "wOM-k6pjot",
-    "name": "Moominvalley Glade",
+    "name": "Moominvalley",
     "imageUrl": "https://sky-planner.com/assets/game/areas/vault/moomin-glade-720.webp",
     "spirits": [
       "vW9xp55w6t",


### PR DESCRIPTION
Update the names of areas since they official have been given names in 0.32.0.

The names I didn't add were:
Passage Stone and Ancient Dock which is the Sand Dunes on the Planner.
Path of Eden which encompasses the second, third, and fourth area of eden. 


