### PR TITLE
Skylender 2022 links

### DIFF
--- a/src/assets/event-instances/days-of-bloom.jsonc
+++ b/src/assets/event-instances/days-of-bloom.jsonc
@@ -11,7 +11,10 @@
     "date": "2022-03-28",
     "endDate": "2022-04-10",
     "shops": ["BtRb90bYtH", "m1hOAdOvnx"],
-    "spirits": ["FwSpcuPQeQ"]
+    "spirits": ["FwSpcuPQeQ"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Bloom-3418261c87dd80b99c9cf42a0267302c?pvs=25"
+    }
   },
   {
     "guid": "-qKo3_DMbw",

--- a/src/assets/event-instances/days-of-color.jsonc
+++ b/src/assets/event-instances/days-of-color.jsonc
@@ -22,7 +22,10 @@
     "date": "2022-06-30",
     "endDate": "2022-07-13",
     "shops": ["ntVyLMOody", "jaDbvOGhtj"],
-    "spirits": ["Qep3FZt66w"]
+    "spirits": ["Qep3FZt66w"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Rainbow-3418261c87dd801aa913ee614fdb4788?pvs=25"
+    }
   },
   {
     "guid": "7H5NE9-K72",

--- a/src/assets/event-instances/days-of-feast.jsonc
+++ b/src/assets/event-instances/days-of-feast.jsonc
@@ -24,7 +24,10 @@
     "date": "2022-12-19",
     "endDate": "2023-01-08",
     "shops": ["sqzCydXmsy", "2C_rKjKCNo", "zoFI7O9DM0"],
-    "spirits": ["_Kw0vriXyP", "d2BGP3fI-Y", "eXRAJOweQm"]
+    "spirits": ["_Kw0vriXyP", "d2BGP3fI-Y", "eXRAJOweQm"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Feast-2408261c87dd80d7bed3f8ef95bf46f2"
+    }
   },
   {
     "guid": "crmlLYIhMM",

--- a/src/assets/event-instances/days-of-fortune.jsonc
+++ b/src/assets/event-instances/days-of-fortune.jsonc
@@ -16,7 +16,10 @@
       "date": "2022-01-24",
       "endDate": "2022-02-06",
         "shops": ["etiMAAMrUG"],
-        "spirits": ["YPStqurD9K", "GlnH4VVPCa"]
+        "spirits": ["YPStqurD9K", "GlnH4VVPCa"],
+        "_calendar": {
+          "href": "https://skydreamers.notion.site/Days-of-Fortune-3418261c87dd80fcab6ed1d402c33a22?pvs=25"
+        }
       },
       {
         "guid": "187kTuPAdi",

--- a/src/assets/event-instances/days-of-giving.jsonc
+++ b/src/assets/event-instances/days-of-giving.jsonc
@@ -17,7 +17,10 @@
   {
     "guid": "7X6qW51tj5",
     "date": "2022-11-22",
-    "endDate": "2022-11-28"
+    "endDate": "2022-11-28",
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Giving-3418261c87dd803a81fec7758eed1bfa?pvs=25"
+    }
   },
   {
     "guid": "6bevujwY8W",

--- a/src/assets/event-instances/days-of-love.jsonc
+++ b/src/assets/event-instances/days-of-love.jsonc
@@ -17,7 +17,10 @@
     "date": "2022-02-07",
     "endDate": "2022-02-22",
     "shops": ["Qui5cN01A3", "0UnDE-9JQY"],
-    "spirits": ["TpqW3-jpkZ", "Zt2a-8SSJr"]
+    "spirits": ["TpqW3-jpkZ", "Zt2a-8SSJr"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Love-3418261c87dd806aa190fd58f177e30a?pvs=25"
+    }
   },
   {
     "guid": "6398vKUGFN",

--- a/src/assets/event-instances/days-of-mischief.jsonc
+++ b/src/assets/event-instances/days-of-mischief.jsonc
@@ -23,7 +23,10 @@
     "date": "2022-10-24",
     "endDate": "2022-11-13",
     "shops": ["NTt-KZd_Za", "MGl2DwfM6Y", "vl6JA53gfO", "JfjTkXjClo"],
-    "spirits": ["PNYNgV6au9"]
+    "spirits": ["PNYNgV6au9"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Mischief-3418261c87dd80c6a650efb6fc787277?pvs=25"
+    }
   },
   {
     "guid": "2oUBCvAWSZ",

--- a/src/assets/event-instances/days-of-nature.jsonc
+++ b/src/assets/event-instances/days-of-nature.jsonc
@@ -16,7 +16,10 @@
     "date": "2022-04-18",
     "endDate": "2022-05-01",
     "shops": ["HzR1C5d1am", "NNulaStjmr"],
-    "spirits": ["4A_HnQqlA9"]
+    "spirits": ["4A_HnQqlA9"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Nature-3418261c87dd80249cb1c205c699acc1?pvs=25"
+    }
   },
   {
     "guid": "T3MrkNukUj",

--- a/src/assets/event-instances/days-of-sunlight.jsonc
+++ b/src/assets/event-instances/days-of-sunlight.jsonc
@@ -4,7 +4,10 @@
     "date": "2022-08-22",
     "endDate": "2022-09-11",
     "shops": ["mmxpUMHHS8"],
-    "spirits": ["tDfqpF3f03"]
+    "spirits": ["tDfqpF3f03"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Days-of-Sunlight-3418261c87dd80ddb45adee51cf643ac?pvs=25"
+    }
   },
   {
     "guid": "bupHF1FUFd",

--- a/src/assets/event-instances/kizuna-ai-collaboration.jsonc
+++ b/src/assets/event-instances/kizuna-ai-collaboration.jsonc
@@ -3,6 +3,9 @@
     "guid": "rGOuzt_d-o",
     "date": "2022-02-25",
     "endDate": "2022-03-10",
-    "shops": ["djY7Ysc5Yf"]
+    "shops": ["djY7Ysc5Yf"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Kizuna-AI-Collaboration-3418261c87dd8015a906cc5753ba1757?pvs=25"
+    }
   }
 ]

--- a/src/assets/event-instances/lazy-days.jsonc
+++ b/src/assets/event-instances/lazy-days.jsonc
@@ -4,6 +4,9 @@
     "date": "2022-09-26",
     "endDate": "2022-10-16",
     "shops": ["txCjbkOUCb"],
-    "spirits": ["k2AhzKJA_Z"]
+    "spirits": ["k2AhzKJA_Z"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Lazy-Days-3418261c87dd8000afbeff6101e17347?pvs=25"
+    }
   }
 ]

--- a/src/assets/event-instances/sky-anniversary.jsonc
+++ b/src/assets/event-instances/sky-anniversary.jsonc
@@ -15,7 +15,10 @@
     "guid": "ekBn-JK2zq",
     "date": "2022-07-18",
     "endDate": "2022-08-03",
-    "spirits": ["V4S-zpi_yY"]
+    "spirits": ["V4S-zpi_yY"],
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Sky-Anniversary-2022-3418261c87dd80788920cacd98da5f4a?pvs=25"
+    }
   },
   {
     "guid": "edzNCG6Irb",

--- a/src/assets/seasons/seasons.jsonc
+++ b/src/assets/seasons/seasons.jsonc
@@ -254,6 +254,9 @@
     ],
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Abyss"
+    },
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Season-of-Abyss-3418261c87dd80a6a837f11f4c63e971?pvs=25"
     }
   },
   {
@@ -274,6 +277,9 @@
     ],
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Performance"
+    },
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Season-of-Performance-3418261c87dd80749771ca396343c8e0?pvs=25"
     }
   },
   {
@@ -294,6 +300,9 @@
     ],
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Shattering"
+    },
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Season-of-Shattering-3418261c87dd804c9a18e09e075a526f?pvs=25"
     }
   },
   {
@@ -315,6 +324,9 @@
     "shops": ["g52YibkF9n", "LO-BcdXa5D", "3jAHLp9lZp", "ph-oKFD2TA"],
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_AURORA"
+    },
+    "_calendar": {
+      "href": "https://skydreamers.notion.site/Season-of-Aurora-3418261c87dd800c9321e67e9d4ae554?pvs=25"
     }
   },
   // #endregion


### PR DESCRIPTION
Updated Skylender links of 2022. According to [PR 487](https://github.com/Silverfeelin/SkyGame-Planner/issues/487).