### PR TITLE
Added Clover Sprout

### DIFF
--- a/src/assets/iaps/base.jsonc
+++ b/src/assets/iaps/base.jsonc
@@ -129,6 +129,14 @@
       "JmFT0Q3IZ2"
     ]
   },
+  {
+    "guid": "z-ApX7yPrr",
+    "name": "Spring Clover Sprout",
+    "price": 0.99,
+    "items": [
+      "-0MdVdgbqv"
+    ]
+  },
   // #endregion
   // #region Platform exclusives
   {

--- a/src/assets/items/store.jsonc
+++ b/src/assets/items/store.jsonc
@@ -283,5 +283,17 @@
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_for_PlayStation#Transcendent_Journey_Pack"
     },
     "order": 561
+  },
+  {
+    "id": 3133,
+    "guid": "-0MdVdgbqv",
+    "type": "HairAccessory",
+    "name": "Spring Clover Sprout",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/83/Netease-Clover-Hairpin-Icon-777-Ed.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/05/Clover-Head-Accessory.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/NetEase/Tree_Planting_Day#Clover_Head_Accessory"
+    },
+    "order": ""
   }
 ]

--- a/src/assets/shops/permanent.jsonc
+++ b/src/assets/shops/permanent.jsonc
@@ -87,5 +87,12 @@
     "name": "Mannequin at Cafe",
     "permanent": "wonderland",
     "itemList": "Lu78MMHJp7"
+  },
+  {
+    "guid": "joQYfxi-yB",
+    "type": "Object",
+    "name": "Web Store (unavailable)",
+    "permanent": true,
+    "iaps": ["z-ApX7yPrr"]
   }
 ]


### PR DESCRIPTION
Even though it's not available currently, I thought that we might as well add it since some players were able to purchase and obtain the item (myself included)

as for the item order, it should be in between the Ocean Veil and Days of Healing Poppy
<img width="750" height="346" alt="image" src="https://github.com/user-attachments/assets/a9130635-40a2-453f-8152-04afcbb1bbe5" />
