### PR TITLE
Added New Props & Minor Carnival Fixes

### DIFF
--- a/src/assets/item-lists/permanent.jsonc
+++ b/src/assets/item-lists/permanent.jsonc
@@ -9,6 +9,8 @@
     "guid": "5WGoG5qsHG",
     "items": [
       { "guid": "DaBtOjTLze", "item": "dvoSMxPFL2", "c": 150 },
+      { "guid": "6md4IJH_KF", "item": "6dzqysO-Ws", "c": 6 },
+      { "guid": "UnawsvFfOx", "item": "EDnMTgYRFC", "c": 8 },
       { "guid": "qHjGSpR3in", "item": "vu_PdLP82M", "c": 10},
       { "guid": "j11cj6HTy4", "item": "dl3FZAnMyu", "c": 15 },
       { "guid": "RCtEFJffQW", "item": "gfQTU53Vni", "c": 20 },
@@ -19,7 +21,7 @@
       { "guid": "xGscxpu7ii", "item": "5HoXo6DF--", "c": 15 },
       { "guid": "Q_biw7tR6f", "item": "DecMXt7qEo", "c": 15 },
       { "guid": "nApik9LEc3", "item": "GivrsXeHVe", "c": 15 },
-      { "guid": "FzA6YujOdl", "item": "c3sT_itCFa", "c": 15 }
+      { "guid": "FzA6YujOdl", "item": "c3sT_itCFa", "c": 15 },
     ]
   },
   {

--- a/src/assets/items/events/days-of-treasure.jsonc
+++ b/src/assets/items/events/days-of-treasure.jsonc
@@ -133,7 +133,7 @@
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Treasure#Treasure_Seeker%E2%80%99s_Banner"
     },
-    "order": 11400
+    "order": 11800
   },
   {
     "id": 3137,

--- a/src/assets/items/seasons/carnival.jsonc
+++ b/src/assets/items/seasons/carnival.jsonc
@@ -644,57 +644,59 @@
   {
     "id": 3126,
     "guid": "9_k0CQ1YsG",
-    "type": "Prop",
-    "name": "Challenge Ball Dispenser Prop",
+    "type": "Special",
+    "name": "Challenge Ball Dispenser",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/26/Challenge-Ball-Dispenser-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Challenge-Ball-Dispenser-Prop.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Prop"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Ball_Dispenser_Prop"
     }
   },
   {
     "id": 3127,
     "guid": "2Vy0pNifOU",
-    "type": "Prop",
-    "name": "Challenge Target Prop",
+    "type": "Special",
+    "name": "Challenge Target",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/Challenge-Target-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/06/Challenge-Target-Prop.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Prop"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Target_Prop"
     }
   },
   {
     "id": 3128,
     "guid": "Arp_S5eGTr",
-    "type": "Prop",
-    "name": "Challenge Token Prop",
+    "type": "Special",
+    "name": "Challenge Token",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/91/Challenge-Token-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ae/Challenge-Token-Prop.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Prop"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Token_Prop"
     }
   },
   {
     "id": 3129,
     "guid": "MyKYmUPlXn",
-    "type": "Prop",
-    "name": "Challenge Bounce Pad Prop",
+    "type": "Furniture",
+    "name": "Challenge Bounce Pad",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5b/Challenge-Bounce-Pad-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Challenge-Bounce-Pad-Prop.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Prop"
-    }
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Bounce_Pad_Prop"
+    },
+    "order": 11400
   },
   {
     "id": 3130,
     "guid": "zgRZHjhJ7s",
-    "type": "Prop",
-    "name": "Challenge Platform Prop",
+    "type": "Furniture",
+    "name": "Challenge Platform",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/39/Challenge-Platform-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/Challenge-Platform-Prop.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Prop"
-    }
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Platform_Prop"
+    },
+    "order": 11700
   },
   {
     "id": 3142,
@@ -719,5 +721,29 @@
     "type": "Special",
     "name": "Heart",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Heart.png"
+  },
+  {
+    "id": 3145,
+    "guid": "6dzqysO-Ws",
+    "type": "Furniture",
+    "name": "Challenge High Bounce Pad",
+    "icon": "https://i.postimg.cc/zGb2YLsg/Screenshot-1.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Challenge-Bounce-Pad-Prop.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Bounce_Pad_Prop"
+    },
+    "order": 11500
+  },
+  {
+    "id": 3146,
+    "guid": "EDnMTgYRFC",
+    "type": "Furniture",
+    "name": "Challenge Enchanced Bounce Pad",
+    "icon": "https://i.postimg.cc/3wgT7fsp/Screenshot-2.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Challenge-Bounce-Pad-Prop.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Bounce_Pad_Prop"
+    },
+    "order": 11600
   }
 ]

--- a/src/assets/items/seasons/carnival.jsonc
+++ b/src/assets/items/seasons/carnival.jsonc
@@ -726,9 +726,9 @@
     "id": 3145,
     "guid": "6dzqysO-Ws",
     "type": "Furniture",
-    "name": "Challenge High Bounce Pad",
-    "icon": "https://i.postimg.cc/zGb2YLsg/Screenshot-1.png",
-    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Challenge-Bounce-Pad-Prop.png",
+    "name": "Challenge Bounce Pad Level 2",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/08/Challenge-Bounce-Pad-Level-2-icon.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c3/Challenge-Bounce-Pad-Prop-Level-2.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Bounce_Pad_Prop"
     },
@@ -738,9 +738,9 @@
     "id": 3146,
     "guid": "EDnMTgYRFC",
     "type": "Furniture",
-    "name": "Challenge Enchanced Bounce Pad",
-    "icon": "https://i.postimg.cc/3wgT7fsp/Screenshot-2.png",
-    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5d/Challenge-Bounce-Pad-Prop.png",
+    "name": "Challenge Bounce Pad Level 3",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/df/Challenge-Bounce-Pad-Level-3-icon.png",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f7/Challenge-Bounce-Pad-Prop-Level-3.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Guide#Challenge_Bounce_Pad_Prop"
     },


### PR DESCRIPTION
Added the 2 new bounce pads to the aviary event store shop; the icon and preview images are temporary until they’re added to the wiki. 
Changed the type for Challenge Target Prop and Challenge Token Prop to `special` instead of `prop` since they don't exist in the wardrobe. 
Fixed all the Carnival props to have the correct type as they should be `furniture` and not `prop`

reference image:
<img width="403" height="435" alt="image" src="https://github.com/user-attachments/assets/4189a61c-e254-4875-8b4b-98c3dae3f59b" />
