### PR TITLE
Updated Revival & Duets Guide

### DIFF
--- a/src/assets/items/seasons/duets.jsonc
+++ b/src/assets/items/seasons/duets.jsonc
@@ -623,5 +623,29 @@
     "type": "Special",
     "name": "Blessing",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/28/Special-event-spell-icon.png"
+  },
+  {
+    "id": 3151,
+    "guid": "PeEt2Wdee8",
+    "type": "Emote",
+    "subtype": "FriendEmote",
+    "name": "Duet Bow",
+    "level": 3,
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b4/Duets-Guide-Action-icon.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Duets_Guide#Expression"
+    }
+  },
+  {
+    "id": 3152,
+    "guid": "aDHnv20PVR",
+    "type": "Emote",
+    "subtype": "FriendEmote",
+    "name": "Duet Bow",
+    "level": 4,
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b4/Duets-Guide-Action-icon.png",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Duets_Guide#Expression"
+    }
   }
 ]

--- a/src/assets/items/seasons/revival.jsonc
+++ b/src/assets/items/seasons/revival.jsonc
@@ -20,7 +20,7 @@
     "id": 641,
     "guid": "5pM1uL5euH",
     "type": "Quest",
-    "name": "Quest 2 (removed)",
+    "name": "Quest 2 (removed 0.25.0)",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#cite_note-Revival_Quest_changes-1"
@@ -37,7 +37,7 @@
     "id": 643,
     "guid": "UtjY-O5GfN",
     "type": "Quest",
-    "name": "Quest 2",
+    "name": "Quest 2 (removed 0.33.5)",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#2"
@@ -54,10 +54,10 @@
     "id": 645,
     "guid": "RrWXNJ8_8U",
     "type": "Quest",
-    "name": "Quest 3",
+    "name": "Quest 2",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#3"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#2"
     }
   },
   {
@@ -78,10 +78,10 @@
     "id": 1968,
     "guid": "LPhMFiY1Gn",
     "type": "Quest",
-    "name": "Quest 4",
+    "name": "Quest 3",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#4"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#3"
     }
   },
   {
@@ -95,10 +95,10 @@
     "id": 1970,
     "guid": "2htYztTTLh",
     "type": "Quest",
-    "name": "Quest 5",
+    "name": "Quest 4",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#5"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#4"
     }
   },
   {
@@ -112,10 +112,10 @@
     "id": 1972,
     "guid": "7NBQOMY8Os",
     "type": "Quest",
-    "name": "Quest 6",
+    "name": "Quest 5",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#6"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#5"
     }
   },
   {
@@ -129,10 +129,10 @@
     "id": 1974,
     "guid": "LKCSYIoEKs",
     "type": "Quest",
-    "name": "Quest 7",
+    "name": "Quest 6",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#7"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#6"
     }
   },
   {
@@ -151,20 +151,20 @@
     "id": 1984,
     "guid": "C2QyP140Rm",
     "type": "Quest",
-    "name": "Quest 8",
+    "name": "Quest 7",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#8"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#7"
     }
   },
   {
     "id": 1985,
     "guid": "6J0eF-rleF",
     "type": "Quest",
-    "name": "Quest 9",
+    "name": "Quest 8",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Exclamation-mark-Ray.png",
     "_wiki": {
-      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#9"
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Season_of_Revival#Quest_#8"
     }
   },
   {
@@ -521,5 +521,12 @@
     "name": "Season Heart",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2a/Revival-seasonal-heart-icon.png",
     "group": "SeasonPass"
-  }
+  },
+  {
+    "id": 3153,
+    "guid": "C9Ch2JYV8r",
+    "type": "Special",
+    "name": "High Five",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/Icon_high_five.png"
+  },
 ]

--- a/src/assets/nodes/seasons/duets.jsonc
+++ b/src/assets/nodes/seasons/duets.jsonc
@@ -27,6 +27,20 @@
   { "guid": "ThNBHH7MYv", "item": "itrEoHB72a", "h": 8 },
   { "guid": "mYEPxkVyYg", "item": "pronMA7m25", "n": "oaCoMDLbv0" },
   { "guid": "oaCoMDLbv0", "item": "kvggIFZaT3" },
+  // After Season (33.5)
+  { "guid": "Jlgksaz8m4", "item": "DtfPuD-xSP", "n": "mOtKTtYTl3" },
+  { "guid": "mOtKTtYTl3", "item": "g5if_hfGQ-", "nw": "JjCOvcE1DF", "n": "2VVii45w-2" },
+  { "guid": "JjCOvcE1DF", "item": "diBkeTRe1G", "c": 65 },
+  { "guid": "2VVii45w-2", "item": "25PSOB8TyZ", "nw": "Fg5sZhNXRr", "n": "amuJMXefZn" },
+  { "guid": "Fg5sZhNXRr", "item": "mEvAN9gteG" },
+  { "guid": "amuJMXefZn", "item": "kSUpmc7BGK", "nw": "gCkIOP31Wu", "n": "miA4x3BAsD" },
+  { "guid": "gCkIOP31Wu", "item": "xGUAqqh4hK" },
+  { "guid": "miA4x3BAsD", "item": "a2jmBtI7SB", "nw": "WdfIUAxfdw", "n": "bWmU0G_mix" },
+  { "guid": "WdfIUAxfdw", "item": "itrEoHB72a", "h": 8, "n": "egF2naBkA0" },
+  { "guid": "egF2naBkA0", "item": "PeEt2Wdee8", "n": "TzEVqnLGQO", "h": 4 },
+  { "guid": "TzEVqnLGQO", "item": "aDHnv20PVR", "h": 8 },
+  { "guid": "bWmU0G_mix", "item": "pronMA7m25", "n": "3WFLfZ66cZ" },
+  { "guid": "3WFLfZ66cZ", "item": "kvggIFZaT3" },
   // #endregion
   // #region Duets
   // #region Cellist's Beginnings

--- a/src/assets/nodes/seasons/revival.jsonc
+++ b/src/assets/nodes/seasons/revival.jsonc
@@ -62,6 +62,24 @@
   { "guid": "MWeMaq6JsY", "item": "C2QyP140Rm" },
   { "guid": "rrRgDjcCYQ", "item": "6J0eF-rleF" },
   { "guid": "LTejN0I19V", "item": "xB3Auq2DFR", "c": 46 },
+  // V4 (0.33.5)
+  { "guid": "lYDaXJDz0C", "item": "ueFGjjCL-f", "nw": "LSUW2irFWr", "n": "GP6j5EJGRy" },
+  { "guid": "LSUW2irFWr", "item": "iPKhdXjEDN", "c": 3 },
+  { "guid": "GP6j5EJGRy", "item": "C9Ch2JYV8r", "nw": "VI1ZhHLx6e", "n": "0cGYsfmwwS", "c": 0 },
+  { "guid": "VI1ZhHLx6e", "item": "x9W_UOZ61W", "c": 3 },
+  { "guid": "0cGYsfmwwS", "item": "RrWXNJ8_8U", "nw": "_EaHMc0rKM", "n": "ddCnd2uZ8o", "ne": "CXWB-2pI0v" },
+  { "guid": "_EaHMc0rKM", "item": "-O5kRr08TU", "c": 3 },
+  { "guid": "CXWB-2pI0v", "item": "BkvIh_1cID" },
+  { "guid": "ddCnd2uZ8o", "item": "LPhMFiY1Gn", "nw": "PYH26uSIzP", "n": "rWwz4Khvtv" },
+  { "guid": "PYH26uSIzP", "item": "9ZSG_CwRwt", "c": 3 },
+  { "guid": "rWwz4Khvtv", "item": "2htYztTTLh", "nw": "balVA8IIwc", "n": "M9njlsU7rJ" },
+  { "guid": "balVA8IIwc", "item": "_5Z1Ee33iH", "c": 3 },
+  { "guid": "M9njlsU7rJ", "item": "7NBQOMY8Os", "nw": "bG513-ozD1", "n": "lCOYa1KxvH" },
+  { "guid": "bG513-ozD1", "item": "N2BbtfMv-4", "c": 3 },
+  { "guid": "lCOYa1KxvH", "item": "LKCSYIoEKs", "nw": "-Xk7ZAkean", "n": "9saWW3ate7", "ne": "aFvxt8VyqZ" },
+  { "guid": "-Xk7ZAkean", "item": "C2QyP140Rm" },
+  { "guid": "aFvxt8VyqZ", "item": "6J0eF-rleF" },
+  { "guid": "9saWW3ate7", "item": "xB3Auq2DFR", "c": 46 }
   // #endregion
   // #region Revival
   // #region Vestige of a Deserted Oasis

--- a/src/assets/spirit-trees/seasons/seasons.jsonc
+++ b/src/assets/spirit-trees/seasons/seasons.jsonc
@@ -187,6 +187,11 @@
     "revisionType": "AfterSeason",
     "node": "dUvJTemimW"
   },
+  {
+    "guid": "ddQmIL9y8R",
+    "revisionType": "AfterSeason",
+    "node": "lYDaXJDz0C"
+  },
   // Nine-Colored Deer Guide
   {
     "guid": "Lvuz1tp6P9",
@@ -1575,6 +1580,11 @@
     "guid": "RSUBTRhzHf",
     "revisionType": "AfterSeason",
     "node": "Qf34nNDqQ_"
+  },
+  {
+    "guid": "xEYB316Q3I",
+    "revisionType": "AfterSeason",
+    "node": "Jlgksaz8m4"
   },
   {
     "guid": "FKLImPk5vB",

--- a/src/assets/spirits/seasons/duets.jsonc
+++ b/src/assets/spirits/seasons/duets.jsonc
@@ -5,7 +5,7 @@
       "name": "Duets Guide",
       "imageUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/eb/Duets-Ultimate-Guide.png",
       "tree": "voApj8nmhQ",
-      "treeRevisions": ["RSUBTRhzHf"],
+      "treeRevisions": ["RSUBTRhzHf", "xEYB316Q3I"],
       "_wiki": {
         "href": "https://sky-children-of-the-light.fandom.com/wiki/Duets_Guide"
       }

--- a/src/assets/spirits/seasons/revival.jsonc
+++ b/src/assets/spirits/seasons/revival.jsonc
@@ -5,7 +5,7 @@
       "name": "Hopeful Steward",
       "imageUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c1/Hopeful-Steward-Revival-Guide.png",
       "tree": "tzCvlmC_Oc",
-      "treeRevisions": ["NPq3lMzoTy", "DxTCih7Txv"],
+      "treeRevisions": ["NPq3lMzoTy", "DxTCih7Txv", "ddQmIL9y8R"],
       "_wiki": {
         "href": "https://sky-children-of-the-light.fandom.com/wiki/Hopeful_Steward"
       }


### PR DESCRIPTION
Updated the Duets Guide to add lvl 3 and lvl 4 bow friendship emote. I have also confirmed that lvl 2 is still 8 hearts (forgot to take a screenshot)

Updated the Revival Guide as the old (pre 33.5) quest 2 has been removed and replaced with high-five. I have confirmed it myself by making a new account and an additional source from the [Sky Wiki Discord](https://discord.com/channels/914660297963352064/1509074348122833006/1509115570866622584). I also renamed the removed quests since there are now two "quest 2 (removed)" they now include the update patch they were removed so we have "quest 2 (removed 0.25.0)" and "quest 2 (removed 0.33.5)"

reference: 
<img width="492" height="651" alt="image" src="https://github.com/user-attachments/assets/fc831635-68c0-4200-bd0b-2c7fd73af3ae" />
<img width="412" height="430" alt="image" src="https://github.com/user-attachments/assets/af450092-a5f7-4a46-b52f-1a18c89933d3" />
