### PR TITLE
Fix: SeasonPass Item "Carnival Puzzle Director Outfit"

### DIFF
--- a/src/assets/items/seasons/carnival.jsonc
+++ b/src/assets/items/seasons/carnival.jsonc
@@ -409,6 +409,7 @@
     "name": "Carnival Puzzle Director Outfit",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d1/Carnival-Puzzle-Director-Outfit-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/Carnival-Puzzle-Director-Outfit-front.png",
+    "group": "SeasonPass",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Carnival_Puzzle_Director#Outfit"
     },


### PR DESCRIPTION
Fix: SeasonPass is needed for item "Carnival Puzzle Director Outfit"

Ref:

<img width="250" alt="Web Page" src="https://github.com/user-attachments/assets/c5b52833-a320-41bd-9209-70a5b5d6c07b" />
<img width="250" alt="In-game Layer" src="https://github.com/user-attachments/assets/3b0329c2-b7e4-40ae-af02-4d2f1fbbd0aa" />
