### PR TITLE
Add: Playfighting Herbalist's Level 3 & 4 FriendEmotes

### DIFF
--- a/src/assets/items/seasons/enchantment.jsonc
+++ b/src/assets/items/seasons/enchantment.jsonc
@@ -888,5 +888,29 @@
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Prop"
     },
     "order": 400
+  },
+  {
+    "id": 3173,
+    "guid": "U3YshimiUo",
+    "type": "Emote",
+    "subtype": "FriendEmote",
+    "name": "Play Fight",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Friend_Action"
+    },
+    "level": 3,
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b9/Play_fight_lvl_2_white_on_black.png"
+  },
+  {
+    "id": 3174,
+    "guid": "XH9iJLNF4F",
+    "type": "Emote",
+    "subtype": "FriendEmote",
+    "name": "Play Fight",
+    "_wiki": {
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist#Friend_Action"
+    },
+    "level": 4,
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b9/Play_fight_lvl_2_white_on_black.png"
   }
 ]

--- a/src/assets/nodes/seasons/enchantment.jsonc
+++ b/src/assets/nodes/seasons/enchantment.jsonc
@@ -274,6 +274,8 @@
   { "guid": "DgAJjNkKNj", "item": "EOIKe7Ya--", "c": 5, "nw": "4XFb4Qvt45", "n": "6p-SEiVak2", "ne": "k4-sMKK5_E" },
   { "guid": "4XFb4Qvt45", "item": "8vNIpRiWxo", "c": 42 },
   { "guid": "k4-sMKK5_E", "item": "X7b5yfYXA_", "c": 20 },
-  { "guid": "6p-SEiVak2", "item": "RBXxOaKIyg", "c": 70 }
+  { "guid": "6p-SEiVak2", "item": "RBXxOaKIyg", "c": 70, "nw": "IJlo8MvkH2", "n": "G-xRkChQ1A" },
+  { "guid": "IJlo8MvkH2", "item": "U3YshimiUo", "h": 4 },
+  { "guid": "G-xRkChQ1A", "item": "XH9iJLNF4F", "h": 8 }
   // #endregion
 ]


### PR DESCRIPTION
Add Playfighting Herbalist's level 3 & 4 `FriendEmote`s

There are new emote nodes above the cape.

Ref: 
1. Wiki in [https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist](https://sky-children-of-the-light.fandom.com/wiki/Playfighting_Herbalist)
2. <img width="2560" height="1440" alt="Sky 2026_6_18 19_55_52" src="https://github.com/user-attachments/assets/b2415ab9-0bcc-4f21-9ceb-2c61773ddeee" />
