### PR TITLE
Added Dye Slots to Props

### DIFF
--- a/src/assets/items/events/days-of-bloom.jsonc
+++ b/src/assets/items/events/days-of-bloom.jsonc
@@ -30,6 +30,12 @@
     "name": "Pink Bloom Teaset",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f3/Icon_prop_days_of_bloom_tea_table.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/53/Tea_table_v2.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom/2021#Pink_Bloom_Teaset"
     },
@@ -75,6 +81,12 @@
     "name": "Purple Bloom Teaset",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/33/Purple_Bloom_Teaset_icon-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/96/Wisteria-teaset-iap-image.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom/2022#Purple_Bloom_Teaset"
     },
@@ -143,6 +155,12 @@
     "name": "Bloom Picnic Basket",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/Days-of-Bloom-Picnic-Blanket-Icon-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/1e/Days-of-Bloom-Picnic-Blanket.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Bloom#Bloom_Picnic_Basket"
     },

--- a/src/assets/items/events/days-of-feast.jsonc
+++ b/src/assets/items/events/days-of-feast.jsonc
@@ -129,6 +129,12 @@
     "name": "Winter Feast Pillow",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/73/Days_of_Feast_Cushion.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/Feast_pillow.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Feast/2021#Winter_Feast_Pillow"
     },

--- a/src/assets/items/events/days-of-love.jsonc
+++ b/src/assets/items/events/days-of-love.jsonc
@@ -76,6 +76,12 @@
     "name": "Days of Love Flowery Archway",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/eb/Days-of-Love-Arch-Icon-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/17/Days-of-Love-Flowery-Archway.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Love/2023#Days_of_Love_Flowery_Archway"
     },

--- a/src/assets/items/events/days-of-nature.jsonc
+++ b/src/assets/items/events/days-of-nature.jsonc
@@ -293,6 +293,12 @@
     "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ec/Blue-Flag-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/ac/Blue-Flag-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Nature/2026#Blue_Flag"
     },

--- a/src/assets/items/events/days-of-rainbow.jsonc
+++ b/src/assets/items/events/days-of-rainbow.jsonc
@@ -551,7 +551,7 @@
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Jellyfish_Kite"
     },
-    "order": 12300
+    "order": 12400
   },
   {
     "id": 3163,
@@ -560,6 +560,12 @@
     "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f4/Lighthorn-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/71/Lighthorn-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Lighthorn_Kite"
     },
@@ -572,6 +578,12 @@
     "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/70/Manatee-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b7/Manatee-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Manatee_Kite"
     },
@@ -581,13 +593,13 @@
     "id": 3165,
     "guid": "G-YytABnZX",
     "name": "Manta Kite",
-    "type": "Furniture",
+    "type": "Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/Manta-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Manta-Kite-real.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Manta_Kite"
     },
-    "order": 11500
+    "order": 12300
   },
   {
     "id": 3166,
@@ -599,19 +611,25 @@
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Turtle_Kite"
     },
-    "order": 12400
+    "order": 12500
   },
   {
     "id": 3167,
     "guid": "1NqdTvGfIw",
     "name": "Whale Kite",
-    "type": "Prop",
+    "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fa/Whale-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3f/Whale-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Whale_Kite"
     },
-    "order": 12500
+    "order": 11650
   },
   {
     "id": 3168,

--- a/src/assets/items/events/days-of-rainbow.jsonc
+++ b/src/assets/items/events/days-of-rainbow.jsonc
@@ -512,6 +512,12 @@
     "type": "Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/16/Butterfly-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/72/Butterfly-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Butterfly_Kite"
     },
@@ -524,6 +530,12 @@
     "type": "Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/65/Bird-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e9/Bird-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Bird_Kite"
     },
@@ -536,6 +548,12 @@
     "type": "Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/94/Crab-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4d/Crab-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Crab_Kite"
     },
@@ -548,6 +566,12 @@
     "type": "Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4d/Jellyfish-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Jellyfish-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Jellyfish_Kite"
     },
@@ -596,6 +620,12 @@
     "type": "Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/da/Manta-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Manta-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Manta_Kite"
     },
@@ -608,6 +638,12 @@
     "type": "Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/bb/Turtle-Kite-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/34/Turtle-Kite-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Color/2026#Turtle_Kite"
     },

--- a/src/assets/items/events/days-of-summer.jsonc
+++ b/src/assets/items/events/days-of-summer.jsonc
@@ -65,6 +65,12 @@
     "name": "Double Deck Chairs",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/dc/Icon_prop_days_of_summer_beach_chairs.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/86/Summer_beach_chairs.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Hiking_Grouch#Prop"
     },

--- a/src/assets/items/events/days-of-sunlight.jsonc
+++ b/src/assets/items/events/days-of-sunlight.jsonc
@@ -25,6 +25,11 @@
     "name": "Campfire Tent",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7d/Days-of-Sunlight-Tent-Prop-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/Days-of-Sunlight-tent-prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Sunlight/2022#Campfire_Tent"
     },

--- a/src/assets/items/events/days-of-treasure.jsonc
+++ b/src/assets/items/events/days-of-treasure.jsonc
@@ -128,8 +128,13 @@
     "guid": "Vo5Sew0Ql4",
     "name": "Treasure Seeker's Banner",
     "type": "Furniture",
-    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2f/X-mark-icon.png",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b3/Treasure-Seeker-Banner-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/38/Treasure-Seeker-Banner-Prop-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Treasure/2026#Treasure_Seeker%E2%80%99s_Banner"
     },
@@ -188,6 +193,12 @@
     "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cd/Naptime-Galley-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a6/Naptime-Galley-Prop-real.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Treasure/2026#Naptime_Galley"
     },

--- a/src/assets/items/events/event-sky-anniversary.jsonc
+++ b/src/assets/items/events/event-sky-anniversary.jsonc
@@ -555,18 +555,20 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/Anniversary-Swag-Cap-Accessory-front.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2026#Swag_Cap"
-    }
+    },
+    "order": 4550
   },
   {
     "id": 3188,
     "guid": "cTvlz4Z8-3",
-    "type": "Prop",
+    "type": "Held",
     "name": "Company Issued Laptop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/44/Anniversary-Company-Issued-Laptop-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/ba/Anniversary-Company-Issued-Laptop-Prop-using.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2026#Company_Issued_Laptop"
-    }
+    },
+    "order": 6050
   },
   {
     "id": 3189,
@@ -577,7 +579,8 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/90/Anniversary-Black-and-Blue-Swag-Hoodie-Cape-front.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2026#Black_and_Blue_Swag_Hoodie"
-    }
+    },
+    "order": 14150
   },
   {
     "id": 3190,
@@ -588,7 +591,8 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Anniversary-Oreo-WFH-Slippers-Shoes-side.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2026#Oreo_Slippers"
-    }
+    },
+    "order": 2800
   },
   {
     "id": 3191,
@@ -599,6 +603,7 @@
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/88/Anniversary-Moth-Plush-Prop-holding.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2026#Moth_Plush"
-    }
+    },
+    "order": 3650
   }
 ]

--- a/src/assets/items/events/event-sky-anniversary.jsonc
+++ b/src/assets/items/events/event-sky-anniversary.jsonc
@@ -32,6 +32,12 @@
     "name": "Sky Anniversary Pennants",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/74/Icon_prop_days_of_sky_pennants.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/68/Days_of_sky_2021_pennants.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2021#Anniversary_Birthday_Flag"
     },

--- a/src/assets/items/events/event-tournament.jsonc
+++ b/src/assets/items/events/event-tournament.jsonc
@@ -181,6 +181,11 @@
     "name": "Tournament Podium",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3e/Tournament-Podium-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8f/Tournament-Podium.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Tournament_of_Triumph/2026#Tournament_Podium"
     },

--- a/src/assets/items/events/workshop-show-and-tell.jsonc
+++ b/src/assets/items/events/workshop-show-and-tell.jsonc
@@ -18,6 +18,12 @@
     "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c4/Blue-Stool-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Blue-Stool-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Workshop_Show_%26_Tell"
     },
@@ -54,6 +60,12 @@
     "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/10/Left-Curtain-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/02/Left-Curtain-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Workshop_Show_%26_Tell"
     },

--- a/src/assets/items/seasons/assembly.jsonc
+++ b/src/assets/items/seasons/assembly.jsonc
@@ -120,6 +120,11 @@
     "name": "Assembly Pillow",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/03/Icon_prop_assembly_pillow.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e5/Prop_forest_treehouse_pillow.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Pillow"
     },

--- a/src/assets/items/seasons/assembly.jsonc
+++ b/src/assets/items/seasons/assembly.jsonc
@@ -236,6 +236,12 @@
     "name": "Assembly Tent",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/Icon_prop_assembly_tent.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/Prop_forest_treehouse_tent.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Assembly_Guide#Tent"
     },
@@ -622,6 +628,12 @@
     "name": "Scaredy Cadet Hammock",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8b/Icon_prop_assembly_hammock.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/Assembly_prop_hammock_down.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Scaredy_Cadet#Prop"
     },
@@ -761,6 +773,11 @@
     "name": "Marching Adventurer Tiki Torch",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/af/Icon_prop_assembly_torch.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/30/Assembly_prop_torch_lit_2.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Marching_Adventurer#Prop"
     },

--- a/src/assets/items/seasons/belonging.jsonc
+++ b/src/assets/items/seasons/belonging.jsonc
@@ -400,6 +400,12 @@
     "name": "Sparkler Parent Pinwheel Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Spell_-_Pinwheel.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/91/Pinwheel_.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sparkler_Parent#Prop"
     },

--- a/src/assets/items/seasons/blue-bird.jsonc
+++ b/src/assets/items/seasons/blue-bird.jsonc
@@ -210,6 +210,11 @@
     "type": "Furniture",
     "name": "Perch Tree",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/c9/Blue-Bird-Guide-Additional-Prop-icon.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Blue_Bird_Guide#Prop"
     },

--- a/src/assets/items/seasons/nesting.jsonc
+++ b/src/assets/items/seasons/nesting.jsonc
@@ -179,6 +179,12 @@
     "name": "Nesting Nook Shelf",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/91/Nesting-Nook-Short-Shelf-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/51/Nesting-Nook-Short-Shelf-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Nook#Shelf"
     },
@@ -191,6 +197,12 @@
     "name": "Nesting Nook Spice Rack",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/Nesting-Nook-Wall-Spice-Rack-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/ff/Nesting-Nook-Wall-Spice-Rack-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Nook#Spice_Rack"
     },
@@ -672,6 +684,12 @@
     "name": "Two Colors Pillow",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/45/Decor-Pillow-Two-Colors-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Decor-Pillow-Two-Colors-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Decor_Pillow_Two_Colors"
     },
@@ -726,6 +744,12 @@
     "name": "Decor Folded Cloth",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/45/Decor-Folded-Cloth-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f4/Decor-Folded-Cloth-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Decor_Folded_Cloth"
     },
@@ -798,6 +822,12 @@
     "name": "Small Classic Rug",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/3c/Small-Classic-Rug-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Small-Classic-Rug-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Small_Classic_Rug"
     },
@@ -1014,6 +1044,12 @@
     "name": "Medium Diamonds Rug",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6b/Medium-Diamonds-Rug-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/c/cb/Medium-Diamonds-Rug-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Medium_Diamonds_Rug"
     },
@@ -1268,6 +1304,12 @@
     "name": "Medium Argyle Rug",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/62/Medium-Argyle-Rug-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b6/Medium-Argyle-Rug-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Medium_Argyle_Rug"
     },

--- a/src/assets/items/seasons/nesting.jsonc
+++ b/src/assets/items/seasons/nesting.jsonc
@@ -161,6 +161,12 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8e/Nesting-Nook-Loveseat-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b9/Nesting-Nook-Loveseat-Prop.png",
     "order": 9100,
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Nook#Couch"
     },
@@ -235,6 +241,12 @@
     "name": "Nesting Solarium Table",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/46/Nesting-Solarium-Dining-Table-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5c/Nesting-Solarium-Dining-Table-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Solarium#Table"
     },
@@ -247,6 +259,12 @@
     "name": "Nesting Solarium Bathtub",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/97/Nesting-Solarium-Bathtub-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/Nesting-Solarium-Bathtub-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "order": 9300,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Solarium#Bathtub"
@@ -443,6 +461,11 @@
     "name": "Nesting Loft Chair",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/fc/Nesting-Loft-Chair-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5e/Nesting-Loft-Chair-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Loft#Chair"
     },
@@ -541,6 +564,12 @@
     "name": "Stone Single Bed",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8d/Stone-Single-Bed-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/5f/Stone-Single-Bed-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Single_Bed"
     },
@@ -589,6 +618,12 @@
     "name": "Stone Tall Shelf",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/86/Stone-Tall-Shelf-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e3/Stone-Tall-Shelf-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Tall_Shelf"
     },
@@ -661,6 +696,12 @@
     "name": "Stone Armchair",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f1/Stone-Armchair-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0c/Stone-Armchair-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Armchair"
     },
@@ -709,6 +750,12 @@
     "name": "Stone Loveseat",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/09/Stone-Loveseat-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d9/Stone-Loveseat-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Loveseat"
     },
@@ -721,6 +768,12 @@
     "name": "Stone Round Dining Table",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/41/Stone-Round-Dining-Table-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ef/Stone-Round-Dining-Table-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Round_Dining_Table"
     },
@@ -769,6 +822,12 @@
     "name": "Stone Square Dining Table",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8c/Stone-Square-Dining-Table-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/01/Stone-Square-Dining-Table-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Square_Dining_Table"
     },
@@ -817,6 +876,12 @@
     "name": "Stone Long Dining Table",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a0/Stone-Long-Dining-Table-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/8a/Stone-Long-Dining-Table-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Long_Dining_Table"
     },
@@ -829,6 +894,12 @@
     "name": "Stone Small Bathtub",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/35/Stone-Small-Bathtub-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/62/Stone-Small-Bathtub-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Small_Bathtub"
     },
@@ -865,6 +936,12 @@
     "name": "Stone Coffee Table",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d1/Stone-Coffee-Table-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/a2/Stone-Coffee-Table-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Nesting_Workshop#Stone_Coffee_Table"
     },

--- a/src/assets/items/seasons/performance.jsonc
+++ b/src/assets/items/seasons/performance.jsonc
@@ -221,6 +221,12 @@
     "name": "Performance Flower Pot Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f8/SOPerformance-flower-pot-icon-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/42/SOPerformance-flower-pot.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Performance_Guide#Prop"
     },

--- a/src/assets/items/seasons/radiance.jsonc
+++ b/src/assets/items/seasons/radiance.jsonc
@@ -120,6 +120,12 @@
     "group": "SeasonPass",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/1/11/Radiance-Leaping-Dancer-prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e9/Radiance-Leaping-Dancer-prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "order": 2200,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Radiance_Leaping_Dancer#Prop"

--- a/src/assets/items/seasons/remembrance.jsonc
+++ b/src/assets/items/seasons/remembrance.jsonc
@@ -191,6 +191,11 @@
     "name": "Remembrance Potted Plant",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/SoRemembrance-Prop-Plants-Morybel-0146.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/6f/SoRemembrance-Prop-Plants.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Remembrance_Guide#Potted_Plant"
     },

--- a/src/assets/items/seasons/sanctuary.jsonc
+++ b/src/assets/items/seasons/sanctuary.jsonc
@@ -252,6 +252,12 @@
     "name": "Jelly Whisperer Prop",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/55/Jelly_whisperer_TS_beach_umbrella_icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/8/84/Jelly_whisperers_beach_umbrella.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Jelly_Whisperer#Prop"
     },

--- a/src/assets/items/seasons/two-embers-part-1.jsonc
+++ b/src/assets/items/seasons/two-embers-part-1.jsonc
@@ -388,6 +388,12 @@
     "name": "Resourceful Recluse Tea Table",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Resourceful-Recluse-Tea-Stall-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/f/f5/Resourceful-Recluse-Tea-Stall-Prop.png",
+    "dye": {
+      "previewUrl": "",
+      "infoUrl": "",
+      "primary": {},
+      "secondary": {}
+    },
     "order": 2500,
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Resourceful_Recluse#Prop"


### PR DESCRIPTION
Added dye slots to the props that are dyeable (of the ones I own). I don't own all the props so I'm fairly certain there are a few more props that are dyeable which I don't know about.

Other small fixes were made as well.
- Updated Days of Treasure banner icon
- Changed the type for some of the Days of Color kites and reordered them
- Changed Anniversary laptop type from prop to held