### PR TITLE
Fix: EC-Cost Small Birthday Cake (The Lower One)

### DIFF
--- a/src/assets/nodes/events/sky-anniversary.jsonc
+++ b/src/assets/nodes/events/sky-anniversary.jsonc
@@ -312,7 +312,7 @@
   { "guid": "coW1RUglku", "item": "avN500gyNA", "n": "kzGKV18TJ5", "nw": "mlDSaukIM5", "ne": "u3-bTDXg9f" },
   { "guid": "mlDSaukIM5", "item": "kXLOaiW5sq", "ec": 25 },
   { "guid": "u3-bTDXg9f", "item": "Yy7tRZUNEY", "ec": 18 },
-  { "guid": "kzGKV18TJ5", "item": "FjtQU-Da97", "c": 2, "nw": "JCt3V6F9Qz", "n": "6InUQZFVvX", "ne": "i2drp4deRF" },
+  { "guid": "kzGKV18TJ5", "item": "FjtQU-Da97", "ec": 2, "nw": "JCt3V6F9Qz", "n": "6InUQZFVvX", "ne": "i2drp4deRF" },
   { "guid": "JCt3V6F9Qz", "item": "cTvlz4Z8-3", "ec": 29 },
   { "guid": "i2drp4deRF", "item": "y54CllfiMA", "c": 45 },
   { "guid": "6InUQZFVvX", "item": "0hJ9DXTWh2", "nw": "Gi-LoOyvs8", "n": "gwp6IVLV4M", "ne": "xCPnntr4c1", "c": 2 },


### PR DESCRIPTION
Event candles are needed for the lower level of the Small Birthday Cake. Though not sure if it is going to change in the game.

Ref:
<img width="2560" height="1440" alt="Sky 2026_7_7 13_22_25" src="https://github.com/user-attachments/assets/5550cb41-651e-4d50-9b86-17c4ccaca315" />
