### PR TITLE
Added SCA cap (kind of broken)

### DIFF
--- a/src/assets/item-lists/events/sky-anniversary.jsonc
+++ b/src/assets/item-lists/events/sky-anniversary.jsonc
@@ -19,5 +19,11 @@
       { "guid": "sriF-cPssf", "item": "h8I7obBDzf", "c": 20 },
       { "guid": "ERynGHlSkt", "item": "9jMnZ23AYP", "h": 10 }
     ]
+  },
+  { //SCA Cap
+    "guid": "7l_QyYl7pB",
+    "items": [
+      { "guid": "1YaOsRZtWO", "item": "6AWIdsfu3k", "c": 0 }
+    ]
   }
 ]

--- a/src/assets/items/events/event-sky-anniversary.jsonc
+++ b/src/assets/items/events/event-sky-anniversary.jsonc
@@ -557,6 +557,7 @@
     "guid": "Yy7tRZUNEY",
     "type": "HairAccessory",
     "name": "Swag Cap",
+    "group": "Limited",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b5/Anniversary-Swag-Cap-Accessory-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/d/d4/Anniversary-Swag-Cap-Accessory-front.png",
     "_wiki": {
@@ -611,5 +612,18 @@
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2026#Moth_Plush"
     },
     "order": 3650
-  }
+  },
+  {
+    "id": 3192,
+    "guid": "6AWIdsfu3k",
+    "type": "HairAccessory",
+    "name": "SCA Cap",
+    "group": "Limited",
+    "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/SCA-Cap-Accessory-icon.png",
+    "previewUrl": "",
+    "_wiki": {
+      "href": ""
+    },
+    "order": 4575
+  },
 ]

--- a/src/assets/items/seasons/two-embers-part-1.jsonc
+++ b/src/assets/items/seasons/two-embers-part-1.jsonc
@@ -725,7 +725,6 @@
     "guid": "8F6QxN0IsD",
     "type": "Prop",
     "name": "Two Embers - Part 1 Movie Poster",
-    "group": "Limited",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0b/Season-of-Ember-P1-movie-poster-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b2/Season-of-Ember-P1-movie-poster.png",
     "order": 2400,

--- a/src/assets/shops/permanent.jsonc
+++ b/src/assets/shops/permanent.jsonc
@@ -68,6 +68,13 @@
     "iaps": ["rY0Zs2qcDM"]
   },
   {
+    "guid": "I8jtphFzX_",
+    "type": "Object",
+    "name": "Clementine",
+    "permanent": "cinema",
+    "itemList": "7l_QyYl7pB"
+  },
+  {
     "guid": "he4MHA7_uC",
     "type": "Object",
     "name": "Nesting Workshop Counter",


### PR DESCRIPTION
I've added the SCA Cap (creator awards black cap), it's just missing the wiki link and preview image. I've also ran into an issue because it redirects to the right page when clicking "find item" but it's not showing on the page. I don't know what the issue is that is causing it since when I tried putting it in the Aviary Event Store it would show but not for the cinema.

Other fixes:
- added limited group to swag cap
- removed limited group from Two Embers - Part 1 Movie Poster

<img width="1379" height="601" alt="image" src="https://github.com/user-attachments/assets/92760273-97cd-49be-abfe-32c2340ec48d" />
