### PR TITLE
Add Wiki Link for Van Gogh IAPs

### DIFF
--- a/src/assets/items/seasons/dear-van-gogh.jsonc
+++ b/src/assets/items/seasons/dear-van-gogh.jsonc
@@ -738,7 +738,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/7/7a/Dear-Van-Gogh-Wheatfield-Cape-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/9/92/Dear-Van-Gogh-Wheatfield-Cape-back.png",
     "_wiki": {
-      "href": ""
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Dear_Van_Gogh#Wheatfield_Cape"
     },
     "order": 12350
   },
@@ -750,7 +750,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/a/aa/Dear-Van-Gogh-Starry-Night-Visage-Mask-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/4e/Dear-Van-Gogh-Starry-Night-Visage-Mask.png",
     "_wiki": {
-      "href": ""
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Dear_Van_Gogh#Starry_Night's_Visage"
     },
     "order": 9050
   },
@@ -762,7 +762,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/6/66/Dear-Van-Gogh-Starry-Night-Kiss-Accessory-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/5/56/Dear-Van-Gogh-Starry-Night-Kiss-Accessory.png",
     "_wiki": {
-      "href": ""
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Dear_Van_Gogh#Starry_Night's_Kiss"
     },
     "order": 1350
   },
@@ -774,7 +774,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/0/0d/Dear-Van-Gogh-Starry-Night-Mantle-Cape-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/36/Dear-Van-Gogh-Starry-Night-Mantle-Cape-back.png",
     "_wiki": {
-      "href": ""
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Dear_Van_Gogh#Starry_Night's_Mantle"
     },
     "order": 12150
   },
@@ -786,7 +786,7 @@
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/49/Dear-Van-Gogh-Starry-Night-Mantle-Accessory-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/e9/Dear-Van-Gogh-Starry-Night-Mantle-Accessory-front.png",
     "_wiki": {
-      "href": ""
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Dear_Van_Gogh#Starry_Night's_Mantle"
     },
     "order": 4350
   }


### PR DESCRIPTION
Add Wiki Link for Van Gogh IAPs, by: https://github.com/Silverfeelin/SkyGame-Planner/issues/513