### PR TITLE
Fixed Fortune Music Box & Van Gogh Teaset

### DIFF
--- a/src/assets/items/events/days-of-fortune.jsonc
+++ b/src/assets/items/events/days-of-fortune.jsonc
@@ -610,13 +610,13 @@
     "id": 3021,
     "guid": "BxcM9aaV_8",
     "name": "Fortune Carousel Music Box",
-    "type": "Prop",
+    "type": "Furniture",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/4/40/Fortune-Carousel-Music-Box-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/b/b8/Fortune-Carousel-Music-box-using.png",
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Days_of_Fortune/2026#Fortune_Carousel_Music_Box"
     },
-    "order": 4800
+    "order": 3250
   },
   {
     "id": 3022,

--- a/src/assets/items/seasons/dear-van-gogh.jsonc
+++ b/src/assets/items/seasons/dear-van-gogh.jsonc
@@ -187,7 +187,7 @@
   {
     "id": 3208,
     "guid": "te5dxg40i2",
-    "type": "Prop",
+    "type": "Furniture",
     "name": "Dear Van Gogh Ultimate Teaset",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/2/2c/Dear-Van-Gogh-Ultimate-Tea-Table-Prop-icon.png",
     "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/32/Dear-Van-Gogh-Ultimate-Guide-Teaset-real.png",
@@ -195,7 +195,7 @@
     "_wiki": {
       "href": "https://sky-children-of-the-light.fandom.com/wiki/Vase_with_Fifteen_Sunflowers#Ultimate_Gifts"
     },
-    "order": 2700
+    "order": 2650
   },
   {
     "id": 3209,


### PR DESCRIPTION
Changed the type for fortune music box and van gogh ultimate teaset to furniture from prop and fixed the order.

Reference: [Issue #514](https://github.com/Silverfeelin/SkyGame-Planner/issues/514)