### PR TITLE
Fix: SCA cap updated missing info

### DIFF
--- a/src/assets/items/events/event-sky-creator-awards.jsonc
+++ b/src/assets/items/events/event-sky-creator-awards.jsonc
@@ -6,9 +6,9 @@
     "name": "SCA Cap",
     "group": "Limited",
     "icon": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/3/37/SCA-Cap-Accessory-icon.png",
-    "previewUrl": "",
+    "previewUrl": "https://static.wikia.nocookie.net/sky-children-of-the-light/images/e/ea/SCA-Cap-Accessory-front.png",
     "_wiki": {
-      "href": ""
+      "href": "https://sky-children-of-the-light.fandom.com/wiki/Sky_Anniversary/2026#Sky_Creator_Awards_Cap"
     },
     "order": 4950
   }


### PR DESCRIPTION
Fix: SCA cap updated missing info from https://github.com/Silverfeelin/SkyGame-Planner/issues/516